### PR TITLE
Add a global setting to require a specific badge prior to enrolment

### DIFF
--- a/index.php
+++ b/index.php
@@ -36,6 +36,17 @@ if (!enrol_is_enabled('easy')) {
     die(get_string('error_disabled_global', 'enrol_easy'));
 }
 
+$plugin = enrol_get_plugin('easy');
+if (!$plugin->is_precondition_satisfied()) {
+    echo $OUTPUT->header();
+    $badge = new \core_badges\badge($plugin->get_config('precondition'));
+    $badgename = $badge->name;
+    echo get_string('error_failing_precondition', 'enrol_easy', $badgename);
+    echo $OUTPUT->footer();
+    exit;
+}
+
+
 $mform = new enrolform();
 
 if ($mform->get_data()) {
@@ -53,8 +64,6 @@ if ($mform->get_data()) {
         $instance = $DB->get_record('enrol', array('courseid'=>$course->course_id, 'enrol'=>'easy'), '*', MUST_EXIST);
 
         if ($course) {
-
-            $plugin = enrol_get_plugin('easy');
 
             if ($instance->status == 1) {
                 echo $OUTPUT->header();

--- a/lang/en/enrol_easy.php
+++ b/lang/en/enrol_easy.php
@@ -50,6 +50,10 @@ $string['qrenableddesc'] = 'Enable Enrol via QR Codes';
 $string['showqronmobile'] = 'Enable QR Code Reader on Mobile';
 $string['showqronmobiledesc'] = 'Enable Enrol via QR Codes on mobile devices. May not work on all mobile browsers.  Preferred use of QR codes is in the Chrome browser and on a desktop, laptop, or Chromebook.';
 
+$string['precondition'] = 'Require this badge prior to enrolment';
+$string['preconditiondesc'] = 'Prevent students from enrolling unless they can show the specified badge. Leave empty if students should always be allowed to enrol. Changing this setting will not remove prior enrolments.';
+$string['no_precondition'] = '(none required)';
+
 $string['easy:unenrolself'] = 'Unenroll from course';
 $string['easy:config'] = 'Configure Easy Enrollment instances';
 $string['easy:delete'] = 'Delete Easy Enrollment instances';
@@ -62,6 +66,7 @@ $string['error_disabled_global'] = 'Easy enrollment is disabled for this course.
 $string['error_enrolstartdate'] = 'Enrollment has not begin for this course yet.';
 $string['error_enrolenddate'] = 'Enrollment for this course has ended.';
 $string['error_invalid_code'] = 'Invalid enrollment code.';
+$string['error_failing_precondition'] = 'You are not allowed to enrol until you can show the "{$a}" badge.';
 
 $string['coursetext'] = 'Course:  ';
 $string['grouptext'] = 'Group:  ';

--- a/lib.php
+++ b/lib.php
@@ -32,6 +32,10 @@ class enrol_easy_plugin extends enrol_plugin {
             return '';
         }
 
+        if (!$this->is_precondition_satisfied()) {
+            return '';
+        }
+
         require_once(dirname(__FILE__) . '/locallib.php');
 
         $enrol_easy_qr = new moodle_url('/enrol/easy/qr.php');
@@ -334,6 +338,31 @@ class enrol_easy_plugin extends enrol_plugin {
     
         parent::enrol_course_delete($course);
 
+    }
+
+    /**
+     * Check whether the current user can show the required badge (if specified).
+     */
+    public function is_precondition_satisfied() : bool {
+        global $USER, $CFG;
+        require_once($CFG->libdir . '/badgeslib.php');
+
+        $precondition = $this->get_config('precondition', '');
+        if (empty($precondition)) {
+            // No precondition, therefore the check passes.
+            return true;
+        }
+
+        // Get all badges that have been awarded to the user in order to check the precondition.
+        $badges = badges_get_user_badges($USER->id);
+        foreach ($badges as $key => $badge) {
+            if ($badge->id == $precondition) {
+                return true;
+            }
+        }
+
+        // User could not show the required badge.
+        return false;
     }
 
 }

--- a/settings.php
+++ b/settings.php
@@ -41,4 +41,13 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configcheckbox('enrol_easy/showqronmobile',
         get_string('showqronmobile', 'enrol_easy'), get_string('showqronmobiledesc', 'enrol_easy'), 0));
 
+    $preconditionchoices = ['' => get_string('no_precondition', 'enrol_easy')];
+    $records = $DB->get_records_sql('SELECT b.id, b.name FROM {badge} b ORDER BY b.id ASC');
+    foreach ($records as $r) {
+        $preconditionchoices[$r->id] = $r->name;
+    }
+
+    $settings->add(new admin_setting_configselect('enrol_easy/precondition',
+        get_string('precondition', 'enrol_easy'), get_string('preconditiondesc', 'enrol_easy'), '', $preconditionchoices));
+
 }

--- a/tests/precondition_test.php
+++ b/tests/precondition_test.php
@@ -1,0 +1,92 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * PHPUnit Tests for testing discussion retrieval
+ *
+ * @package   enrol_easy
+ * @copyright 2021 Jan Dageförde <jan@dagefor.de>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace enrol_easy;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->libdir . '/badgeslib.php');
+
+/**
+ * PHPUnit Tests for testing easy enrolment preconditions
+ *
+ * @package   enrol_easy
+ * @copyright 2021 Jan Dageförde <jan@dagefor.de>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class enrol_easy_precondition_testcase extends \advanced_testcase {
+
+    /**
+     * Test that a new group with the name of the cohort is created.
+     */
+    public function test_enrol_requires_badge() {
+        global $DB;
+        $this->resetAfterTest();
+
+        $now = time();
+        $badge = new \stdClass();
+        $badge->id = null;
+        $badge->name = "Test course badge";
+        $badge->description = "Testing course badge";
+        $badge->timecreated = $now;
+        $badge->timemodified = $now;
+        $badge->usercreated = 0;
+        $badge->usermodified = 0;
+        $badge->issuername = "Test issuer";
+        $badge->issuerurl = "http://issuer-url.domain.co.nz";
+        $badge->issuercontact = "issuer@example.com";
+        $badge->expiredate = null;
+        $badge->expireperiod = null;
+        $badge->type = BADGE_TYPE_SITE;
+        $badge->messagesubject = "Test message subject for course badge";
+        $badge->message = "Test message body for course badge";
+        $badge->attachment = 1;
+        $badge->notification = 0;
+        $badge->status = BADGE_STATUS_ACTIVE;
+        $badge->version = "Version 1";
+        $badge->language = "en";
+        $badge->imagecaption = "Image caption";
+        $badge->imageauthorname = "Image author's name";
+        $badge->imageauthoremail = "author@example.com";
+        $badge->imageauthorname = "Image author's name";
+
+        $badgeid = $DB->insert_record('badge', $badge, true);
+        $badge1 = new \core_badges\badge($badgeid);
+
+        // Require badge as precondition.
+        $plugin = enrol_get_plugin('easy');
+        $plugin->set_config('precondition', $badgeid);
+
+        // Create two us, but award the badge only to the first one.
+        $user1 = $this->getDataGenerator()->create_user();
+        $user2 = $this->getDataGenerator()->create_user();
+        $badge1->issue($user1->id, true);
+
+        // First user should fulfil the precondition, and the other should not.
+        $this->setUser($user1->id);
+        $this->assertTrue($plugin->is_precondition_satisfied());
+        $this->setUser($user2->id);
+        $this->assertFalse($plugin->is_precondition_satisfied());
+    }
+}

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020120700;
+$plugin->version   = 2021011900;
 $plugin->release  = 'v 1.7.1';
 $plugin->requires  = 2018051700;
 $plugin->cron      = 0;


### PR DESCRIPTION
This is a little enhancement of the easy enrolment plugin: It allows administrators to specify a badge that users have to show prior to enrolment.

This could be used, for instance, to require users to complete onboarding tasks (e.g., sign privacy declarations) prior to using courses of the site.

This feature has been sponsored by @lernlink who required this enhancement for a customer's Moodle site.